### PR TITLE
Fix custom scalars in OTP GraphQL types

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,9 @@ const config = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
+  rules: {
+    eqeqeq: ['error', 'always', {null: 'ignore'}],
+  },
   overrides: [
     {
       files: [

--- a/packages/client/src/App/BaseMap/Sidebar/DirectionsListBox/DirectionsListBox.tsx
+++ b/packages/client/src/App/BaseMap/Sidebar/DirectionsListBox/DirectionsListBox.tsx
@@ -80,17 +80,23 @@ const DirectionItinerary = memo(
     const {startTime, endTime, duration, legs, classNames} = props;
 
     const startTimeStr = useMemo(
-      // TODO: Determine timezone.
-      () => formatTimeTz(new Date(startTime), TIME_FORMAT, {timeZone: ''}),
+      () =>
+        startTime != null
+          ? // TODO: Determine timezone.
+            formatTimeTz(new Date(startTime), TIME_FORMAT, {timeZone: ''})
+          : '',
       [startTime]
     );
     const endTimeStr = useMemo(
-      // TODO: Determine timezone.
-      () => formatTimeTz(new Date(endTime), TIME_FORMAT, {timeZone: ''}),
+      () =>
+        endTime != null
+          ? // TODO: Determine timezone.
+            formatTimeTz(new Date(endTime), TIME_FORMAT, {timeZone: ''})
+          : '',
       [endTime]
     );
     const durationStr = useMemo(
-      () => formatShortDuration(duration),
+      () => (duration != null ? formatShortDuration(duration) : ''),
       [duration]
     );
 

--- a/packages/otp/codegen.ts
+++ b/packages/otp/codegen.ts
@@ -13,7 +13,7 @@ const config: CodegenConfig = {
         // https://github.com/opentripplanner/OpenTripPlanner/blob/c1a91969c5007e539d580926d9e52c15b3f9e7b0/src/main/java/org/opentripplanner/apis/gtfs/GraphQLScalars.java.
         scalars: {
           Duration: 'string',
-          GeoJson: 'geojson#GeoJSON',
+          GeoJson: 'geojson#GeoJSON', // Type import from package
           Grams: 'number',
           Long: 'number',
           Polyline: 'string',

--- a/packages/otp/codegen.ts
+++ b/packages/otp/codegen.ts
@@ -7,7 +7,18 @@ const config: CodegenConfig = {
   schema: OTP_GTFS_GRAPHQL_ENDPOINT,
   generates: {
     './dist/graphql.ts': {
-      plugins: ['typescript'],
+      plugins: ['typescript', 'typescript-operations'],
+      config: {
+        // Gathered from
+        // https://github.com/opentripplanner/OpenTripPlanner/blob/c1a91969c5007e539d580926d9e52c15b3f9e7b0/src/main/java/org/opentripplanner/apis/gtfs/GraphQLScalars.java.
+        scalars: {
+          Duration: 'string',
+          GeoJson: 'geojson#GeoJSON',
+          Grams: 'number',
+          Long: 'number',
+          Polyline: 'string',
+        },
+      },
     },
   },
 } as const;

--- a/packages/otp/package.json
+++ b/packages/otp/package.json
@@ -25,11 +25,13 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.2",
+    "@graphql-codegen/typescript-operations": "^4.2.0",
     "@internal/constants": "workspace:*",
     "@internal/script-utils": "workspace:*",
     "@octokit/request": "^8.1.6",
     "@octokit/request-error": "^5.0.1",
     "@octokit/types": "^12.4.0",
+    "@types/geojson": "^7946.0.14",
     "@types/lodash-es": "^4.17.12",
     "dotenv": "^16.4.1",
     "glob": "^10.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@graphql-codegen/cli':
         specifier: ^5.0.2
         version: 5.0.2(@types/node@20.8.2)(graphql@16.8.1)(typescript@5.3.3)
+      '@graphql-codegen/typescript-operations':
+        specifier: ^4.2.0
+        version: 4.2.0(graphql@16.8.1)
       '@internal/constants':
         specifier: workspace:*
         version: link:../constants
@@ -202,6 +205,9 @@ importers:
       '@octokit/types':
         specifier: ^12.4.0
         version: 12.4.0
+      '@types/geojson':
+        specifier: ^7946.0.14
+        version: 7946.0.14
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12


### PR DESCRIPTION
Adds custom scalars in OTP GTFS GraphQL types.

These scalars are not well documented by OTP, in either its docs or its schema. The types are gathered from their Java definitions in the [API source code](https://github.com/opentripplanner/OpenTripPlanner/blob/c1a91969c5007e539d580926d9e52c15b3f9e7b0/src/main/java/org/opentripplanner/apis/gtfs/GraphQLScalars.java).